### PR TITLE
Update Redis service variables

### DIFF
--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -42,7 +42,7 @@ resources: {}
 
 env:
   DATABASE_URL:  postgres://postgres:postgres@$(POSTGRESQL_SERVICE_HOST):$(POSTGRESQL_SERVICE_PORT)/postgres
-  REDIS_URL: redis://$(REDIS_SERVICE_HOST):$(REDIS_SERVICE_PORT)
+  REDIS_URL: redis://$(REDIS_MASTER_SERVICE_HOST):$(REDIS_MASTER_SERVICE_PORT)
 # Configure the persistence.
 # This also allows live reload in minikube.
 persistence:


### PR DESCRIPTION
The upstream Redis chart integrated the cluster support (see
https://github.com/kubernetes/charts/pull/4662), therefore the name of
the environment variables needs to be adjusted to reflect the changes.