### PR TITLE
Bump api chart version

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RYR api chart
 name: api
-version: 0.1.3
+version: 0.2.0
 appVersion: 0.1.1


### PR DESCRIPTION
A new version is required after updating the chart.