### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,12 @@ jobs:
             - "0b:0b:0f:19:89:13:94:a8:34:30:b4:13:cb:90:78:25"
 
       - run:
+          name: Configure git
+          command: |
+            git config --global user.email "circleci@requestyoracks.org"
+            git config --global user.name "CircleCI"
+
+      - run:
           name: Install tools
           command: tests/circle/install.sh
 

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -17,12 +17,6 @@ cd "${GROOT}"
 git checkout -b gh-pages origin/gh-pages 2>/dev/null || git checkout gh-pages
 
 # Check for new packages.
-if [ -d dist ]; then
-  echo "Nothing to publish."
-  previous_branch
-  exit 0
-fi
-
 NEW_PACKAGES=0
 for f in $(ls dist/*); do
   if [ ! -f "basename ${f}" ]; then


### PR DESCRIPTION
Git needs to be configured with an identity in order to be able to push to
the gh-page branch.