### PR TITLE
[api] Include postgresql secrets

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RYR api chart
 name: api
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.1

--- a/charts/api/templates/deployment.yaml
+++ b/charts/api/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
                 name: {{ template "ryr-api.fullname" . }}
             - secretRef:
                 name: ryr-api-secrets
+            - secretRef:
+                name: postgresql
           {{- if .Values.env }}
           env:
             {{- range $key, $value := .Values.env }}


### PR DESCRIPTION
The API needs the postgresql password in order to boot, therefore it
makes sense to include the postgresql secrets into this chart.