### PR TITLE
[api] Fix secrets

### DIFF
--- a/charts/api/Chart.yaml
+++ b/charts/api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: RYR api chart
 name: api
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.1.1

--- a/charts/api/templates/deployment.yaml
+++ b/charts/api/templates/deployment.yaml
@@ -44,10 +44,13 @@ spec:
                 name: {{ template "ryr-api.fullname" . }}
             - secretRef:
                 name: ryr-api-secrets
-            - secretRef:
-                name: postgresql
-          {{- if .Values.env }}
           env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: postgres-password
+          {{- if .Values.env }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value }}


### PR DESCRIPTION
Instead of importing the full `postgresql` secrets, this patch cherry
picks the specific value for the password and assign it to the
appropriate environment variable.